### PR TITLE
feat: add 'Onboard my repo' issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
+++ b/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
@@ -1,0 +1,20 @@
+name: Onboard my repo
+description: Request onboarding for a repository
+title: "[Onboard]: "
+labels: ["onboarding"]
+assignees: []
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for requesting repository onboarding! Tell us what kind of repo it is.
+- type: dropdown
+  id: repo-type
+  attributes:
+    label: Repository type
+    description: What kind of repository is this?
+    options:
+      - dotnet
+      - javascript
+  validations:
+    required: true


### PR DESCRIPTION
Adds a new GitHub issue form `Onboard my repo` with a single dropdown for the repository type.

## Changes
- New `.github/ISSUE_TEMPLATE/06-onboard_repo.yaml` issue form
- Dropdown `Repository type` with options: `dotnet`, `javascript`

Kept intentionally simple for now; more fields can be added later.