### PR TITLE
fix: apply gitops onboarding label

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
+++ b/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
@@ -1,7 +1,7 @@
 name: Onboard my repo
 description: Request onboarding for a repository
 title: "[Onboard]: "
-labels: ["onboarding"]
+labels: ["gitops-onboard"]
 assignees: []
 body:
 - type: markdown


### PR DESCRIPTION
## Summary

- Updates the shared "Onboard my repo" issue form to apply `gitops-onboard`.
- Aligns onboarding issues with the label listened to by `platform.github.bot`.
- Notes that GitHub repository configuration is Terraform-managed; direct label reconciliation may remove some metadata, but that is acceptable for this onboarding trigger label.

## Test Plan

- [x] Ran `git diff --check`.
- [x] Verified `gitops-onboard` exists in `CanadaLifeUK/.github` with `gh label list`.
