### PR TITLE
feat: add onboarding issue form parameters

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
+++ b/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
@@ -16,15 +16,15 @@ body:
     placeholder: claims-portal-api
   validations:
     required: true
-- type: dropdown
-  id: deployment-environment
+- type: checkboxes
+  id: deployment-environments
   attributes:
-    label: Deployment environment
-    description: Which environment should be onboarded first?
+    label: Deployment environments
+    description: Which environments should be onboarded?
     options:
-      - dev
-      - pre
-      - prd
+      - label: dev
+      - label: pre
+      - label: prd
   validations:
     required: true
 - type: input
@@ -33,16 +33,6 @@ body:
     label: Git branch
     description: Branch Platform Operator should reconcile from.
     value: main
-  validations:
-    required: true
-- type: dropdown
-  id: repo-type
-  attributes:
-    label: Repository type
-    description: What kind of repository is this?
-    options:
-      - dotnet
-      - javascript
   validations:
     required: true
 - type: dropdown

--- a/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
+++ b/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
@@ -7,7 +7,34 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thanks for requesting repository onboarding! Tell us what kind of repo it is.
+      Thanks for requesting repository onboarding! These values are used by Platform Operator to prepare the tenant GitOps sync.
+- type: input
+  id: application-name
+  attributes:
+    label: Application name
+    description: Name of the application being onboarded. This becomes the GitOps sync name, deploy path, and workload namespace.
+    placeholder: claims-portal-api
+  validations:
+    required: true
+- type: dropdown
+  id: deployment-environment
+  attributes:
+    label: Deployment environment
+    description: Which environment should be onboarded first?
+    options:
+      - dev
+      - pre
+      - prd
+  validations:
+    required: true
+- type: input
+  id: git-branch
+  attributes:
+    label: Git branch
+    description: Branch Platform Operator should reconcile from.
+    value: main
+  validations:
+    required: true
 - type: dropdown
   id: repo-type
   attributes:
@@ -16,5 +43,19 @@ body:
     options:
       - dotnet
       - javascript
+  validations:
+    required: true
+- type: dropdown
+  id: datadog-language
+  attributes:
+    label: Datadog language
+    description: Application runtime language for Datadog instrumentation.
+    options:
+      - dotnet
+      - java
+      - js
+      - python
+      - ruby
+      - php
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
+++ b/.github/ISSUE_TEMPLATE/06-onboard_repo.yaml
@@ -12,8 +12,8 @@ body:
   id: application-name
   attributes:
     label: Application name
-    description: Name of the application being onboarded. This becomes the GitOps sync name, deploy path, and workload namespace.
-    placeholder: claims-portal-api
+    description: Name of the application being onboarded. This becomes the GitOps sync name and workload namespace.
+    placeholder: sample-app
   validations:
     required: true
 - type: checkboxes


### PR DESCRIPTION
## Summary
- Add application name, deployment environment, and Git branch fields to the default onboarding issue form.
- Keep repository type selection and add Datadog language as a dropdown for Probot consumption.

## Test Plan
- [x] git diff --check

Related issue: none